### PR TITLE
Change plugin command

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['logstash']['instance_default']['plugins_source_url']     = 'https://dow
 default['logstash']['instance_default']['plugins_checksum']       = 'e4fa08cac70f97e30d4d043fcab817b72c301631713376c5c21824d5d89cae3e'
 default['logstash']['instance_default']['plugins_install_type']   = 'native' # native|tarball ( only native after 1.5 )
 default['logstash']['instance_default']['plugins_check_if_installed'] = 'lib/logstash/filters/translate.rb'
+default['logstash']['instance_default']['plugins_install_command'] = 'plugin' # should be 'logstash-plugin' after 2.2
 
 default['logstash']['instance_default']['log_file']   = 'logstash.log'
 default['logstash']['instance_default']['java_home']  = '/usr/lib/jvm/java-6-openjdk' # openjdk6 on ubuntu

--- a/libraries/logstash_util.rb
+++ b/libraries/logstash_util.rb
@@ -37,7 +37,9 @@ module Logstash
     platform_major_version = determine_platform_major_version(node)
     case node['platform']
     when 'ubuntu'
-      if platform_major_version >= 6.10
+      if platform_major_version >= 16.04
+        'systemd'
+      elsif platform_major_version >= 6.10
         'upstart'
       else
         'sysvinit'

--- a/providers/plugins.rb
+++ b/providers/plugins.rb
@@ -23,6 +23,7 @@ def load_current_resource
   @instance_dir = "#{@base_directory}/#{@instance}"
   @install_type = new_resource.install_type || Logstash.get_attribute_or_default(node, @instance, 'plugins_install_type')
   @install_check = new_resource.install_check || Logstash.get_attribute_or_default(node, @instance, 'plugins_check_if_installed')
+  @install_command = new_resource.install_command || Logstash.get_attribute_or_default(node, @instance, 'plugins_install_command')
 end
 
 action :create do
@@ -36,11 +37,13 @@ action :create do
   ls_instance = @instance
   ls_instance_dir = @instance_dir
   ls_install_check = @install_check
+  ls_install_command = @install_command
 
   case @install_type
   when 'native'
-    ex = execute "bin/plugin install #{ls_name}" do
-      command "bin/plugin install #{ls_name}"
+    install_command = "bin/#{ls_install_command} install #{ls_name}"
+    ex = execute install_command do
+      command install_command
       user    ls_user
       group   ls_group
       cwd     ls_instance_dir

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -104,7 +104,7 @@ action :enable do
           args: args,
           user: svc[:user],
           group: svc[:group],
-          description: svc[:description],
+          description: svc[:description] || svc[:name],
           max_heap: svc[:max_heap],
           min_heap: svc[:min_heap],
           gc_opts: svc[:gc_opts],

--- a/resources/plugins.rb
+++ b/resources/plugins.rb
@@ -19,3 +19,4 @@ attribute :group, kind_of: String
 attribute :base_directory, kind_of: String
 attribute :install_type, kind_of: String
 attribute :install_check, kind_of: String
+attribute :install_command, kind_of: String

--- a/templates/default/init/upstart/tarball.erb
+++ b/templates/default/init/upstart/tarball.erb
@@ -1,4 +1,4 @@
-description "Logstash"
+description <%= @description.inspect %>
 author "Chef"
 
 start on (filesystem and net-device-up)

--- a/templates/default/init/upstart/tarball.erb
+++ b/templates/default/init/upstart/tarball.erb
@@ -31,4 +31,4 @@ script
   <% end -%>
 end script
 
-emits logstash-server-running
+emits logstash-<%= @name %>-running


### PR DESCRIPTION
That's better...

So this is to fix the fact that the `plugin` command changed to `logstash-plugin` after version 2.2 and it borks any plugin installs with later versions.

This  is a minimally invasive quickfix